### PR TITLE
Update GN logstash filter to support quick lookup and fix tests

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -1,2 +1,19 @@
 # logstash-filter-greynoise
-Example filter plugin. This should help bootstrap your effort to write your own filter plugin!
+
+You can build this project on your machine locally or alternative use the docker file to build and run an environment in Docker.
+
+To use Docker, run the following:
+
+```
+# build the docker container for local dev
+make build-docker
+
+# shell into docker environment
+make shell-docker
+
+# set GN key for tests
+export GN_API_KEY=<GN key>
+
+# run tests
+bundle exec rspec
+``` 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM jruby:9
+
+WORKDIR /usr/src/app
+
+COPY Rakefile Gemfile Gemfile.lock logstash-filter-greynoise.gemspec ./
+COPY spec ./spec
+COPY lib ./lib
+
+RUN bundle install

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
+MKFILE_DIR := $(patsubst %/,%,$(dir $(MKFILE_PATH)))
+
+DOCKER_IMAGE_TAG := logstash-gn-dev
+DOCKER_ARGS ?= -v $(MKFILE_DIR):/usr/src/app -w /usr/src/app
+
+build-docker:
+	@docker build . -t $(DOCKER_IMAGE_TAG)
+
+shell-docker:
+	@docker run -it $(DOCKER_ARGS) --entrypoint /bin/bash $(DOCKER_IMAGE_TAG)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ It is fully free and fully open source. The license is Apache 2.0, meaning you a
 
 ## Documentation
 
-The Greynoise filter adds information about IP addresses from logstash events via the Greynoise API.
+The GreyNoise filter adds information about IP addresses from logstash events via the GreyNoise API.
 
 GreyNoise is a system that collects and analyzes data on Internet-wide scanners.
 GreyNoise collects data on benign scanners such as Shodan.io, as well as malicious actors like SSH and telnet worms.
@@ -26,19 +26,34 @@ $LS_HOME/bin/logstash-plugin install logstash-filter-greynoise-0.1.7.gem
 ```
 
 ### 2. Filter Configuration
-Add the following inside the filter section of your logstash configuration:
 
 ```sh
 filter {
   greynoise {
-    ip => "ip_value"                 # string (required, reference to ip address field)
-    key => "your_greynoise_key"      # string (optional, no default)
-    target => "greynoise"            # string (optional, default = greynoise)
-    hit_cache_size => 100            # number (optional, default = 0)
-    hit_cache_ttl => 6               # number (optional, default = 60) 
+    ip             => "ip_value"              # string (required, reference to ip address field)
+    full_context   => true                    # bool (optional, whether to use context lookup, default false)
+    key            => "your_greynoise_key"    # string (required)
+    target         => "greynoise"             # string (optional, default = greynoise)
+    hit_cache_size => 100                     # number (optional, default = 0)
+    hit_cache_ttl  => 6                       # number (optional, default = 60) 
   }
 }
 ```
+The GreyNoise Logstash filter plugin can be used in two different modes:
+
+##### Quick IP Enrichment
+In this mode documents (default) are enriched with a bool field `seen` which is true if GreyNoise has seen this IP or false otherwise. 
+
+This mode is faster than doing full enrichment and should be used for better performance on high-volume/-throughput event streams.
+If you have a data pipeline with multiple enrichment points, you can use the boolean field to later enrich the document with IP information from GreyNoise's context endpoint.
+
+##### Full IP Enrichment
+
+In this mode (`full_context => true`), documents are enriched with full context from GreyNoise API if the IP has been observed by GreyNoise. 
+
+This mode is slower than doing quick IP enrichment and might be reasonable for low-volume/-throughput event streams. 
+
+**NOTE**: Beware that the full context document from GreyNoise API can be large and as such the cache can grow quickly in size. Set the cache size accordingly to prevent high memory consumption by the cache.
 
 Print plugin version:
 

--- a/logstash-filter-greynoise.gemspec
+++ b/logstash-filter-greynoise.gemspec
@@ -1,8 +1,8 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-filter-greynoise'
-  s.version       = '0.1.7'
+  s.version       = '0.1.8'
   s.licenses      = ['Apache-2.0']
-  s.summary = 'This greynoise filter takes contents in the ip field and returns greynoise api data (see https://greynoise.io/ for more info).'
+  s.summary = 'This greynoise filter takes contents in the IP field and returns GreyNoise API data (see https://developer.greynoise.io/ for more info).'
   s.description     = 'This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install logstash-filter-greynoise. This gem is not a stand-alone program'
   s.homepage = 'https://github.com/nicksherron/logstash-filter-greynoise'
   s.authors       = ['nsherron90']
@@ -18,9 +18,7 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "filter" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_development_dependency 'logstash-devutils'
+  s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'lru_redux', "~> 1.1.0"
-
-
 end

--- a/spec/filters/greynoise_spec.rb
+++ b/spec/filters/greynoise_spec.rb
@@ -3,33 +3,47 @@ require_relative '../spec_helper'
 require "logstash/filters/greynoise"
 
 describe LogStash::Filters::Greynoise do
-
   describe "defaults" do
-    let(:config) do <<-CONFIG
+    let(:config) do
+      api_key = ENV["GN_API_KEY"]
+      <<-CONFIG
       filter {
         greynoise {
-          ip => "ip"
+          ip => "%{ip}"          
+          key => "#{api_key}"          
         }
       }
-    CONFIG
-    # end
+      CONFIG
+    end
 
     sample("ip" => "8.8.8.8") do
       insist { subject }.include?("greynoise")
-
-      expected_fields = %w(greynoise.ip greynoise.seen)
+      expected_fields = %w(ip seen code)
       expected_fields.each do |f|
         insist { subject.get("greynoise") }.include?(f)
       end
+      insist { subject.get("greynoise").get("code").equal?("0x05") }
     end
+
+    sample("ip" => "4.2.1.A") do
+      insist { subject.get("tags") }.include?("_greynoise_filter_invalid_ip")
+    end
+  end
+
+  describe "invalid_key" do
+    let(:config) do
+      <<-CONFIG
+      filter {
+        greynoise {
+          ip => "%{ip}"          
+          key => "BAD_KEY"          
+        }
+      }
+      CONFIG
+    end
+
+    sample("ip" => "8.8.8.8") do
+      insist { subject.get("tags") }.include?("_greynoise_filter_invalid_api_key")
     end
   end
 end
-#
-#
-#     sample("message" => "some text") do
-#       expect(subject).to include("message")
-#       expect(subject.get('message')).to eq('Hello World')
-#     end
-#   end
-# end


### PR DESCRIPTION
### Summary of Changes

* Updates README to explain use of `quick` vs `context` and tuning options
* Adds `full_context` option to use context API (otherwise defaults to quick IP lookup)
* Requires API key (deprecates use of v1 unauthenticated endpoint)
* Updates tests (assumes CI will provided GN API key)